### PR TITLE
New text formatting features

### DIFF
--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
@@ -104,6 +104,7 @@ data class TgMessage(
     @SerializedName("author_signature")
     val authorSignature: String? = null,
     val text: String? = null,
+    val entities: List<TgEntity>? = null,
     val caption: String? = null,
     override val animation: TgAny? = null,
     override val photo: List<TgAny>? = null,
@@ -128,6 +129,13 @@ data class TgMessage(
     val effectiveText
         get() = text ?: caption
 }
+
+data class TgEntity(
+    val offset: Int?,
+    var length: Int?,
+    val type: String?,
+    var url: String? = null,
+)
 
 data class TgUpdate(
     @SerializedName("update_id")

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBridge.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBridge.kt
@@ -6,6 +6,7 @@ import dev.vanutp.tgbridge.common.models.LastMessage
 import dev.vanutp.tgbridge.common.models.LastMessageType
 import dev.vanutp.tgbridge.common.models.TBCommandContext
 import dev.vanutp.tgbridge.common.models.TBPlayerEventData
+import dev.vanutp.tgbridge.common.parser.Markdown2HTMLParser
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -133,10 +134,13 @@ abstract class TelegramBridge {
             rawMinecraftText.removePrefix(prefix)
         }
         val escapedText = textWithoutPrefix.escapeHTML()
+        val formattedText = if (config.messages.parseMarkdownInMinecraftToTelegramMessages)
+            Markdown2HTMLParser.parse(escapedText)
+        else escapedText
 
         val currText = lang.telegram.chatMessage.formatLang(
             "username" to e.username,
-            "text" to (bluemapLink ?: escapedText),
+            "text" to (bluemapLink ?: formattedText),
         )
         val currDate = Clock.systemUTC().instant()
 

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/models/Config.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/models/Config.kt
@@ -54,6 +54,14 @@ data class GameMessagesConfig(
         "Default value: 0 (disabled)",
     )
     val mergeWindow: Int? = 0,
+    @YamlComment(
+        "Set to true to enable parsing Telegram Entities (message formatting) to Minecraft chat messages.",
+    )
+    val styledTelegramMessagesInMinecraft: Boolean = true,
+    @YamlComment(
+        "Set to true to enable parsing Markdown to HTML in Minecraft to Telegram chat messages.",
+    )
+    val parseMarkdownInMinecraftToTelegramMessages: Boolean = true,
 )
 
 @Serializable

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/models/Lang.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/models/Lang.kt
@@ -2,6 +2,8 @@ package dev.vanutp.tgbridge.common.models
 
 import com.charleskorn.kaml.YamlComment
 import kotlinx.serialization.Serializable
+import net.kyori.adventure.text.format.TextDecoration
+import java.util.*
 
 @Serializable
 data class LangAdvancements(
@@ -29,6 +31,10 @@ data class LangTelegram(
 
 @Serializable
 data class MessageMeta(
+    val hoverOpenInTelegram: String = "Open in Telegram",
+    val hoverOpenInBrowser: String = "Open in Web Browser",
+    val hoverCopyToClipboard: String = "Copy to clipboard",
+    val hoverTagToReply: String = "Tag him/her",
     val reply: String = "[R {sender}: {text}]",
     val replyToMinecraft: String = "[R {text}]",
     val forward: String = "[F {from}]",
@@ -45,8 +51,32 @@ data class MessageMeta(
 )
 
 @Serializable
+data class MessageFormatting(
+    val linkColor: String = "#FFFF55",
+    val linkFormatting: List<TextDecoration>? = Collections.singletonList(TextDecoration.UNDERLINED),
+    val mentionColor: String = "#FFFF55",
+    val mentionFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val hashtagColor: String = "#FFFF55",
+    val hashtagFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val codeColor: String = "#AAAAAA",
+    val codeFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val spoilerColor: String = "#AAAAAA",
+    val spoilerFormatting: List<TextDecoration>? = Collections.singletonList(TextDecoration.OBFUSCATED),
+    val spoilerReplaceWithChar: String? = "▌",
+    val replyColor: String = "#AAAAAA",
+    val replyFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val forwardColor: String = "#AAAAAA",
+    val forwardFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val mediaColor: String = "#FFFF55",
+    val mediaFormatting: List<TextDecoration>? = Collections.emptyList(),
+    val pinnedMessageColor: String = "#FFFF55",
+    val pinnedMessageFormatting: List<TextDecoration>? = Collections.emptyList(),
+)
+
+@Serializable
 data class LangMinecraft(
     val messageMeta: MessageMeta = MessageMeta(),
+    val messageFormatting: MessageFormatting = MessageFormatting(),
 )
 
 @Serializable

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/FormattingManager.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/FormattingManager.kt
@@ -1,0 +1,119 @@
+package dev.vanutp.tgbridge.common.parser
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.TextDecoration
+import dev.vanutp.tgbridge.common.parser.StyleManager.applyStyle
+import dev.vanutp.tgbridge.common.parser.StyleManager.isDecorationsContains
+import dev.vanutp.tgbridge.common.parser.StyleManager.isDecorationsEquals
+import dev.vanutp.tgbridge.common.TgMessage
+import dev.vanutp.tgbridge.common.ConfigManager.lang
+
+object FormattingManager {
+
+    fun getEntityNamesFromComponent(component: TextComponent): List<String> {
+        val output = ArrayList<String>()
+        if (isItTextLinkComponent(component)) output.add("text_link")
+        if (isItUrlLinkComponent(component)) output.add("url")
+        if (isDecorationsEquals(component, lang.minecraft.messageFormatting.mentionFormatting)
+            && component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.mentionColor.lowercase()) == true
+            && component.content().startsWith("@")) output.add("mention")
+        if (isDecorationsEquals(component, lang.minecraft.messageFormatting.hashtagFormatting)
+            && component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.hashtagColor.lowercase()) == true
+            && component.content().startsWith("#")) output.add("hashtag")
+        if (isDecorationsEquals(component, lang.minecraft.messageFormatting.hashtagFormatting)
+            && component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.hashtagColor.lowercase()) == true
+            && component.content().startsWith("$")) output.add("cashtag")
+        if (isItSpoiler(component)) output.add("spoiler")
+        if (isItCodeComponent(component)) output.add("code")
+        if (isIt(component, TextDecoration.BOLD, output, false)) output.add("bold")
+        if (isIt(component, TextDecoration.ITALIC, output, false)) output.add("italic")
+        if (isIt(component, TextDecoration.UNDERLINED, output, false)) output.add("underline")
+        if (isIt(component, TextDecoration.STRIKETHROUGH, output, false)) output.add("strikethrough")
+
+        return output
+    }
+
+    fun addChatLink(message: TgMessage, component: TextComponent): TextComponent {
+        return component.clickEvent(ClickEvent.openUrl("https://t.me/c/${-message.chat.id-1000000000000}/" + (if (message.messageThreadId!=null) "${message.messageThreadId}/" else "") + "${message.messageId}"))
+            .hoverEvent(Component.text(lang.minecraft.messageMeta.hoverOpenInTelegram).asHoverEvent())
+    }
+
+    fun isItSpoiler(component: TextComponent): Boolean = component.hoverEvent()?.value() is TextComponent &&
+            lang.minecraft.messageFormatting.spoilerReplaceWithChar
+                ?.repeat(getFromSpoilerComponent(component).content().length) == component.content() &&
+            lang.minecraft.messageFormatting.spoilerFormatting?.any { !component.hasDecoration(it) } == false &&
+            component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.spoilerColor.lowercase()) == true
+
+    fun getFromSpoilerComponent(component: TextComponent): TextComponent = component.hoverEvent()?.value() as TextComponent
+
+    fun appendToSpoilerComponent(component: TextComponent, spoilerText: String): TextComponent = appendToSpoilerComponent(component, Component.text(spoilerText))
+    fun appendToSpoilerComponent(component: TextComponent, spoilerComponent: TextComponent): TextComponent =
+        applyStyle(
+            component = Component.text(
+                lang.minecraft.messageFormatting.spoilerReplaceWithChar
+                    ?.repeat(getFromSpoilerComponent(component).content().length + spoilerComponent.content().length).toString()
+            ),
+            decorations = lang.minecraft.messageFormatting.spoilerFormatting,
+            hover = Component.text().append(getFromSpoilerComponent(component)).append(spoilerComponent).build(),
+            color = lang.minecraft.messageFormatting.spoilerColor
+        )
+
+    fun getAsSpoilerComponent(spoilerText: String): TextComponent = getAsSpoilerComponent(Component.text(spoilerText))
+    fun getAsSpoilerComponent(spoilerComponent: TextComponent): TextComponent =
+        applyStyle(
+            component = Component.text(
+                lang.minecraft.messageFormatting.spoilerReplaceWithChar
+                    ?.repeat(spoilerComponent.content().length).toString()
+            ),
+            decorations = lang.minecraft.messageFormatting.spoilerFormatting,
+            hover = spoilerComponent,
+            color = lang.minecraft.messageFormatting.spoilerColor
+        )
+
+    fun isItCodeComponent(component: TextComponent): Boolean =
+        isDecorationsEquals(component, lang.minecraft.messageFormatting.codeFormatting) &&
+                component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.codeColor.lowercase()) == true
+    fun getAsCodeComponent(code: String): TextComponent = getAsCodeComponent(Component.text(code))
+    fun getAsCodeComponent(component: TextComponent): TextComponent =
+        applyStyle(
+            component = component,
+            color = lang.minecraft.messageFormatting.codeColor,
+            clickEvent = ClickEvent.copyToClipboard(component.content()),
+            hover = Component.text(lang.minecraft.messageMeta.hoverCopyToClipboard),
+            insert = component.content()
+        )
+
+    fun isItLinkComponent(component: TextComponent): Boolean =
+        isDecorationsEquals(component, lang.minecraft.messageFormatting.linkFormatting) &&
+                component.clickEvent() != null &&
+                component.color()?.asHexString()?.lowercase()?.equals(lang.minecraft.messageFormatting.linkColor.lowercase()) == true
+    fun isItUrlLinkComponent(component: TextComponent): Boolean =
+        isItLinkComponent(component) &&
+                component.clickEvent()?.value() == component.content()
+    fun isItTextLinkComponent(component: TextComponent): Boolean =
+        isItLinkComponent(component) &&
+                component.clickEvent()?.value() != component.content()
+    fun getAsLinkComponent(link: String): TextComponent = getAsLinkComponent(Component.text(link))
+    fun getAsLinkComponent(linkComponent: TextComponent): TextComponent = getAsLinkComponent(linkComponent, linkComponent.content())
+    fun getAsLinkComponent(text: String, url: String): TextComponent = getAsLinkComponent(Component.text(text), url)
+    fun getAsLinkComponent(component: TextComponent, url: String): TextComponent =
+        applyStyle(
+            component = component,
+            color = lang.minecraft.messageFormatting.linkColor,
+            clickEvent = ClickEvent.openUrl(url),
+            hover = Component.text(lang.minecraft.messageMeta.hoverOpenInBrowser)
+        )
+    fun getUrlFromLinkComponent(component: TextComponent): String = (component.clickEvent()?.value()) ?: component.content()
+
+    fun isIt(component: TextComponent, decorations: List<TextDecoration>, othersOfThis: List<String> = emptyList(), strictly:Boolean = true): Boolean = (if (strictly) isDecorationsEquals(component, decorations) else isDecorationsContains(component, decorations)) && !othersOfThis.any {
+        (it == "spoiler" && lang.minecraft.messageFormatting.spoilerFormatting?.containsAll(decorations) == true) ||
+                (it == "code" && lang.minecraft.messageFormatting.codeFormatting?.containsAll(decorations) == true) ||
+                ((it == "hashtag" || it == "cashtag") && lang.minecraft.messageFormatting.hashtagFormatting?.containsAll(decorations) == true) ||
+                (it == "mention" && lang.minecraft.messageFormatting.mentionFormatting?.containsAll(decorations) == true) ||
+                ((it == "url" || it == "text_link") && lang.minecraft.messageFormatting.linkFormatting?.containsAll(decorations) == true)
+    }
+    fun isIt(component: TextComponent, decoration: TextDecoration, othersOfThis: List<String> = emptyList(), strictly:Boolean = true): Boolean = isIt(component, listOf(decoration), othersOfThis, strictly)
+
+}

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/Markdown2HTMLParser.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/Markdown2HTMLParser.kt
@@ -1,0 +1,100 @@
+package dev.vanutp.tgbridge.common.parser
+
+import java.util.*
+
+object Markdown2HTMLParser {
+
+    private val textLinkAllTextRegex = Regex("((.*?)(?<!\\\\)\\[(.*?)(?<!\\\\)]\\((.*?)(?<!\\\\)\\))*?(.*?)")
+    private val textLinkRegex = Regex("(?<!\\\\)\\[(.*?)(?<!\\\\)]\\((.*?)(?<!\\\\)\\)")
+    private val textLinkTextRegex = Regex("(?<!\\\\)\\[(.*?)(?<!\\\\)]\\(")
+    private val textLinkURLRegex = Regex("(?<!\\\\)]\\((.*?)(?<!\\\\)\\)")
+
+    fun parse(
+        markdown: String,
+        tagMap: Map<String, String> = mapOf(
+            "**" to "b",
+            "*" to "i",
+            "__" to "u",
+            "~~" to "s",
+            "||" to "tg-spoiler",
+            "```" to "pre",
+            "`" to "code",
+        ),
+        textLinkAllTextRegex: Regex = this.textLinkAllTextRegex,
+        textLinkRegex: Regex = this.textLinkRegex,
+        textLinkTextRegex: Regex = this.textLinkTextRegex,
+        textLinkURLRegex: Regex = this.textLinkURLRegex,
+    ): String {
+        val codeOrPreBlocksMap = mutableMapOf<Int, Int>()
+        val codeOrPreList = listOf("```", "`")
+        var codeOrPreBlockOpenedAt = 0
+
+        val stack = Stack<String>()
+        val result = StringBuilder()
+        var i = 0
+
+        while (i < markdown.length) {
+            when {
+                markdown[i] == '\\' && i + 1 < markdown.length -> {
+                    result.append(markdown[i + 1])
+                    i += 2
+                }
+                else -> {
+                    var matched = false
+                    for ((key, tag) in tagMap.entries.sortedByDescending { it.key.length }) {
+                        if (markdown.startsWith(key, i)) {
+                            if (stack.isNotEmpty() && codeOrPreList.contains(stack.last()) && stack.last() != key) result.append(key)
+                            else if (stack.isNotEmpty() && stack.last() == key) {
+                                result.append("</${tag}>")
+                                stack.removeAt(stack.lastIndex)
+                                if (codeOrPreList.contains(key)) {
+                                    stack.forEach { result.append("<${tagMap[it]}>") }
+                                    codeOrPreBlocksMap[codeOrPreBlockOpenedAt] = result.length
+                                }
+                            } else if (stack.isEmpty() || (stack.last() != key && !stack.contains(key))) {
+                                if (codeOrPreList.contains(key)) {
+                                    stack.asReversed()
+                                        .forEach { result.append("</${tagMap[it]}>") }
+                                    codeOrPreBlockOpenedAt = result.length
+                                }
+                                result.append("<${tag}>")
+                                stack.add(key)
+                            } else {
+                                result.append(key)
+                            }
+                            i += key.length
+                            matched = true
+                            break
+                        }
+                    }
+                    if (!matched) {
+                        result.append(markdown[i])
+                        i++
+                    }
+                }
+            }
+        }
+        while (stack.isNotEmpty()) {
+            val key = stack.removeAt(stack.lastIndex)
+            val tag = tagMap[key] ?: ""
+            result.append("</${tag}>")
+            if (codeOrPreList.contains(key)) stack.clear()
+        }
+        var parsed = result.toString()
+        if (parsed.matches(textLinkAllTextRegex)) parsed =
+            textLinkRegex.replace(result.toString()) { matched ->
+                var isInCodeOrPreBlock = false
+                codeOrPreBlocksMap.forEach { (start, end) -> if (matched.range.first>start && matched.range.last<end) isInCodeOrPreBlock = true }
+                if (isInCodeOrPreBlock) return@replace matched.value
+                val linkMatched = textLinkURLRegex.find(matched.value) ?: return@replace matched.value
+                val displayTextMatched = textLinkTextRegex.find(matched.value) ?: return@replace matched.value
+                "<a href=\"${
+                    linkMatched.value.substring(2, linkMatched.value.length - 1)
+                }\">${
+                    displayTextMatched.value.substring(1, displayTextMatched.value.length - 2)
+                }</a>"
+            }
+        return parsed
+    }
+
+}

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/StyleManager.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/StyleManager.kt
@@ -1,0 +1,87 @@
+package dev.vanutp.tgbridge.common.parser
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import java.util.*
+import kotlin.collections.ArrayList
+
+object StyleManager {
+
+    fun isDecorationsEquals(component: TextComponent, decorations: List<TextDecoration>?): Boolean {
+        val componentFormatting = getIsSetDecorations(component)
+        return componentFormatting.containsAll(decorations ?: emptyList()) && (decorations
+            ?: emptyList()).containsAll(componentFormatting)
+    }
+    fun isDecorationsContains(component: TextComponent, decorations: List<TextDecoration>?): Boolean {
+        val componentFormatting = getIsSetDecorations(component)
+        return componentFormatting.containsAll(decorations ?: emptyList())
+    }
+
+    fun getIsSetDecorations(component: TextComponent): List<TextDecoration> = component.decorations().filter { it.value.equals(TextDecoration.State.TRUE) } .keys.toList()
+
+    fun getAllOfChildren(component: TextComponent): MutableList<TextComponent> {
+        val output = ArrayList<TextComponent>()
+        val stack = Stack<TextComponent>()
+        stack.push(component)
+        var tempComponent: TextComponent
+        while (stack.isNotEmpty()) {
+            tempComponent = stack.pop()
+            val split = splitComponent(tempComponent)
+            if (split.size > 1) {
+                split.reversed().forEach { stack.push(it) }
+            } else output.add(tempComponent)
+        }
+        return output
+    }
+
+    fun splitComponent(component: TextComponent): List<TextComponent> {
+        val output = ArrayList<TextComponent>()
+        val components = component.children().map { it as TextComponent }
+        output.add(crateComponentAndCopyFormatting(component.content(), component))
+        if (components.isNotEmpty()) {
+            val hasStyle = component.hasStyling()
+            output.addAll(components.map {
+                if (hasStyle) it.toBuilder().mergeStyle(component).build()
+                else it
+            })
+        }
+        return output
+    }
+
+    fun crateComponentAndCopyFormatting(text: String, component: TextComponent): TextComponent = Component.text(text)
+        .style(component.style())
+
+    fun applyStyle(
+        component: TextComponent,
+        color: String? = "#FFFFFF",
+        decorations: List<TextDecoration>? = emptyList(),
+        hover: TextComponent? = null,
+        clickEvent: ClickEvent? = null,
+        insert: String? = null
+    ): TextComponent = applyStyle(component, TextColor.fromHexString(color ?: "#FFFFFF"), decorations, hover, clickEvent, insert)
+    fun applyStyle(
+        component: TextComponent,
+        color: TextColor? = NamedTextColor.WHITE,
+        decorations: List<TextDecoration>? = emptyList(),
+        hover: TextComponent? = null,
+        clickEvent: ClickEvent? = null,
+        insert: String? = null
+    ): TextComponent {
+        val builder = component.toBuilder()
+        if (color != null) builder.color(color)
+        if (decorations?.isNotEmpty() == true) decorateAll(builder, decorations)
+        if (hover != null) builder.hoverEvent(hover.asHoverEvent())
+        if (clickEvent != null) builder.clickEvent(clickEvent)
+        if (insert != null) builder.insertion(insert)
+        return builder.build()
+    }
+
+    fun decorateAll(component: TextComponent, decorations: List<TextDecoration>?): TextComponent =
+        decorateAll(component.toBuilder(), decorations).build()
+    fun decorateAll(builder: TextComponent.Builder, decorations: List<TextDecoration>?): TextComponent.Builder =
+        builder.apply {  -> decorations?.forEach { this.decoration(it, true) } }
+}

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/TgEntities2TextComponentParser.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/parser/TgEntities2TextComponentParser.kt
@@ -1,0 +1,98 @@
+package dev.vanutp.tgbridge.common.parser
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import dev.vanutp.tgbridge.common.ConfigManager.lang
+import dev.vanutp.tgbridge.common.TgEntity
+import dev.vanutp.tgbridge.common.TgMessage
+
+object TgEntities2TextComponentParser {
+
+    fun parse(message: TgMessage, text: String, entities: List<TgEntity>?): TextComponent {
+        if (entities == null) return Component.text(text)
+        val components = mutableListOf<TextComponent>()
+        val currentEntities = ArrayList<TgEntity>()
+        val nextEntities = ArrayList<TgEntity>()
+        var isLegacy = false
+        var isSpoiler = false
+        var previousIsSpoiler = false
+        var tempText = ""
+        entities.forEach { if (it.offset == 0) {
+            currentEntities.add(it)
+            nextEntities.remove(it)
+        }}
+        for (i in text.indices) {
+            tempText += text[i]
+            entities.forEach {
+                if (it.offset!! + it.length!! == i+1) {
+                    isLegacy = true
+                    nextEntities.remove(it)
+                }
+                if (it.offset == i+1) {
+                    isLegacy = true
+                    nextEntities.add(it)
+                }
+            }
+            if (isLegacy || i == text.length-1) {
+                isLegacy = false
+                var tempComponent  = Component.text(tempText).toBuilder()
+                currentEntities.forEach {
+                    when (it.type) {
+                        "bold" -> tempComponent.decoration(TextDecoration.BOLD, true)
+                        "italic" -> tempComponent.decoration(TextDecoration.ITALIC, true)
+                        "underline" -> tempComponent.decoration(TextDecoration.UNDERLINED, true)
+                        "strikethrough" -> tempComponent.decoration(TextDecoration.STRIKETHROUGH, true)
+                        "text_link" -> tempComponent = FormattingManager.getAsLinkComponent(
+                            tempComponent.build(),
+                            it.url!!
+                        ).toBuilder()
+                        "url" -> tempComponent = FormattingManager.getAsLinkComponent(tempComponent.build()).toBuilder()
+                        "mention" -> StyleManager.decorateAll(
+                            tempComponent,
+                            lang.minecraft.messageFormatting.mentionFormatting
+                        ).color(
+                            TextColor.fromHexString(lang.minecraft.messageFormatting.mentionColor))
+                            .clickEvent(ClickEvent.suggestCommand(tempText))
+                            .insertion(tempText)
+                            .hoverEvent(Component.text(lang.minecraft.messageMeta.hoverTagToReply).asHoverEvent())
+                        "hashtag", "cashtag" -> StyleManager.decorateAll(
+                            tempComponent,
+                            lang.minecraft.messageFormatting.hashtagFormatting
+                        ).color(
+                            TextColor.fromHexString(lang.minecraft.messageFormatting.hashtagColor))
+                            .clickEvent(ClickEvent.openUrl("https://t.me/c/${-message.chat.id-1000000000000}/" + (if (message.messageThreadId!=null) "${message.messageThreadId}/" else "") + "${message.messageId}"))
+                            .hoverEvent(Component.text(lang.minecraft.messageMeta.hoverOpenInTelegram).asHoverEvent())
+                        "spoiler" -> isSpoiler = true
+                        "code", "pre" -> tempComponent = FormattingManager.getAsCodeComponent(tempComponent.build()).toBuilder()
+                    }
+                }
+                if (isSpoiler) {
+                    if (previousIsSpoiler) {
+                        tempComponent = FormattingManager.appendToSpoilerComponent(
+                            components.last(),
+                            tempComponent.build()
+                        ).toBuilder()
+                        components.removeLast()
+                    }
+                    else {
+                        tempComponent = FormattingManager.getAsSpoilerComponent(tempComponent.build()).toBuilder()
+                        previousIsSpoiler = true
+                    }
+                    components.add(tempComponent.build())
+                }
+                else {
+                    if (previousIsSpoiler) previousIsSpoiler = false
+                    components.add(tempComponent.build())
+                }
+                isSpoiler = false
+                tempText = ""
+                currentEntities.clear()
+                currentEntities.addAll(nextEntities)
+            }
+        }
+        return components.fold(Component.text()) { acc, component -> acc.append(component) } .build()
+    }
+}

--- a/translations/lang-ru.yml
+++ b/translations/lang-ru.yml
@@ -13,6 +13,10 @@ telegram:
   playerListZeroOnline: "📝 <b>Онлайн 0</b>"
 minecraft:
   messageMeta:
+    hoverOpenInTelegram: "Открыть в Telegram"
+    hoverOpenInBrowser: "Открыть в браузере"
+    hoverCopyToClipboard: "Копировать в буфер обмена"
+    hoverTagToReply: "Упомянуть"
     reply: "[О {sender}: {text}]"
     replyToMinecraft: "[О {text}]"
     forward: "[П {from}]"
@@ -26,3 +30,29 @@ minecraft:
     voiceMessage: "[Голосовое сообщение]"
     poll: "[Опрос: {title}]"
     pin: "[закрепляет сообщение]"
+  messageFormatting:
+    linkColor: "#FFFF55"
+    linkFormatting:
+      - "UNDERLINED"
+    mentionColor: "#FFFF55"
+    mentionFormatting: [ ]
+    hashtagColor: "#FFFF55"
+    hashtagFormatting: [ ]
+    codeColor: "#AAAAAA"
+    codeFormatting: [ ]
+    spoilerColor: "#AAAAAA"
+    spoilerFormatting:
+      - "OBFUSCATED"
+    spoilerReplaceWithChar: "▌"
+    replyColor: "#AAAAAA"
+    replyFormatting:
+      - "BOLD"
+    forwardColor: "#AAAAAA"
+    forwardFormatting:
+      - "BOLD"
+    mediaColor: "#FFFF55"
+    mediaFormatting:
+      - "BOLD"
+    pinnedMessageColor: "#AAAAAA"
+    pinnedMessageFormatting:
+      - "BOLD"


### PR DESCRIPTION
### Telegram -> Minecraft messages:
- Parsing Telegram Entities to kyori components and apply message formatting in chat.
- Simple open special messages and media in Telegram (by click it)
- Open URL and hyperlinks in browser (by click it)
- More formatting customization (like a custom color for media)

### Minecraft -> Telegram messages:
- Parsing Markdown from Minecraft message to HTML which will then be converted to Telegram Entities automatically by Telegram. Supported tags:
  + `**` -> **bold**;
  + `*` -> *italic*;
  + `__` -> <ins>underline</ins>;
  + `~~` -> ~~strikethrough~~;
  + `||` -> spoiler;
  + \` -> `code`;
  + \``` -> ```code block```
  + `[{text}]({URL})` -> [hyperlink](https://github.com/vanutp/tgbridge);

![image](https://github.com/user-attachments/assets/8137f559-e76f-4ffe-b585-b479263b830b)
![2024-12-09_14 17 09](https://github.com/user-attachments/assets/f61287de-7c43-4e34-867d-9efe7adbcbb0)
![2024-12-09_14 47 35](https://github.com/user-attachments/assets/ded4c8dd-9b91-43a7-8169-e26c26666789)
![2024-12-09_14 49 08](https://github.com/user-attachments/assets/38516dc8-4ec5-4185-a9fa-ee6931095711)
