### PR TITLE
PAPER: /tghide and /tgshow

### DIFF
--- a/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/EventManager.kt
+++ b/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/EventManager.kt
@@ -88,16 +88,16 @@ class EventManager(private val plugin: PaperBootstrap) : Listener {
 
     private fun registerCommandHandlers() {
         plugin.getCommand("tgbridge")!!.setExecutor { commandSender, _, _, args ->
-            if (args[0] == "reload") {
-                return@setExecutor plugin.tgbridge.onReloadCommand(
-                    TBCommandContext(
-                        reply = { text ->
-                            commandSender.sendMessage(text)
-                        }
-                    )
-                )
+            if (args.toList() != listOf("reload")) {
+                return@setExecutor false
             }
-            return@setExecutor false
+            return@setExecutor plugin.tgbridge.onReloadCommand(
+                TBCommandContext(
+                    reply = { text ->
+                        commandSender.sendMessage(text)
+                    }
+                )
+            )
         }
 
         plugin.getCommand("tgshow")!!.setExecutor { commandSender, _, _, args ->

--- a/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/EventManager.kt
+++ b/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/EventManager.kt
@@ -88,16 +88,26 @@ class EventManager(private val plugin: PaperBootstrap) : Listener {
 
     private fun registerCommandHandlers() {
         plugin.getCommand("tgbridge")!!.setExecutor { commandSender, _, _, args ->
-            if (args.toList() != listOf("reload")) {
-                return@setExecutor false
-            }
-            return@setExecutor plugin.tgbridge.onReloadCommand(
-                TBCommandContext(
-                    reply = { text ->
-                        commandSender.sendMessage(text)
-                    }
+            if (args[0] == "reload") {
+                return@setExecutor plugin.tgbridge.onReloadCommand(
+                    TBCommandContext(
+                        reply = { text ->
+                            commandSender.sendMessage(text)
+                        }
+                    )
                 )
-            )
+            }
+            return@setExecutor false
+        }
+
+        plugin.getCommand("tgshow")!!.setExecutor { commandSender, _, _, args ->
+            commandSender.getServer().getPlayer(commandSender.getName())?.removeScoreboardTag("hidden-telegram")
+            return@setExecutor true
+        }
+
+        plugin.getCommand("tghide")!!.setExecutor { commandSender, _, _, args ->
+            commandSender.getServer().getPlayer(commandSender.getName())?.addScoreboardTag("hidden-telegram")
+            return@setExecutor true
         }
     }
 }

--- a/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperPlatform.kt
+++ b/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperPlatform.kt
@@ -5,13 +5,18 @@ import net.kyori.adventure.text.Component
 import net.minecraft.locale.Language
 import org.bukkit.plugin.java.JavaPlugin
 import kotlin.io.path.absolute
+import org.bukkit.Bukkit
 
 class PaperPlatform(private val plugin: JavaPlugin) : Platform() {
     override val name = "paper"
     override val configDir = plugin.dataFolder.toPath().absolute()
 
     override fun broadcastMessage(text: Component) {
-        plugin.server.broadcast(text)
+        for (p in Bukkit.getOnlinePlayers()) {
+            if(!p.getScoreboardTags().contains("hidden-telegram")) {
+                p.sendMessage(text)
+            }
+        }
     }
 
     override fun getOnlinePlayerNames(): Array<String> {

--- a/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperPlatform.kt
+++ b/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperPlatform.kt
@@ -5,17 +5,14 @@ import net.kyori.adventure.text.Component
 import net.minecraft.locale.Language
 import org.bukkit.plugin.java.JavaPlugin
 import kotlin.io.path.absolute
-import org.bukkit.Bukkit
 
 class PaperPlatform(private val plugin: JavaPlugin) : Platform() {
     override val name = "paper"
     override val configDir = plugin.dataFolder.toPath().absolute()
 
     override fun broadcastMessage(text: Component) {
-        for (p in Bukkit.getOnlinePlayers()) {
-            if(!p.getScoreboardTags().contains("hidden-telegram")) {
-                p.sendMessage(text)
-            }
+        for (p in plugin.server.onlinePlayers.filterNot { it.scoreboardTags.contains("hidden-telegram") }) {
+            p.sendMessage(text)
         }
     }
 

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -8,3 +8,11 @@ commands:
     description: Minecraft Telegram Bridge
     usage: /<command>
     permission: tgbridge.command
+  tghide:
+    description: Hides all messages from telegram
+    usage: /<command>
+    permission: tgbridge.command.hide
+  tgshow:
+    description: Brings Telegram messages back if you hidden it by /tghide
+    usage: /<command>
+    permission: tgbridge.command.show


### PR DESCRIPTION
A small change that adds commands for Paper, allowing players to hide and display messages from Telegram in the game.
To be honest, I don't like this implementation, as it uses scoreboard tags, which is not the most optimal solution, but it works. 
The solution is rather temporary... But there's nothing more permanent than something temporary, right? :') 
I think it could be easily extended to other platforms, but I'm unfamiliar with Forge, Fabric (and kotlin). 
I also tried to integrate these commands into sub-commands for /tgbridge, but without creating a hint system for players, this would be a worse solution than separating them into separate commands.