### PR TITLE
fix for folia platform

### DIFF
--- a/implementations/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperBootstrap.kt
+++ b/implementations/paper/src/main/kotlin/dev/vanutp/tgbridge/paper/PaperBootstrap.kt
@@ -1,5 +1,7 @@
 package dev.vanutp.tgbridge.paper
 
+import java.util.concurrent.TimeUnit
+import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
 class PaperBootstrap : JavaPlugin() {
@@ -7,7 +9,7 @@ class PaperBootstrap : JavaPlugin() {
 
     override fun onEnable() {
         EventManager(this).register()
-        server.scheduler.scheduleSyncDelayedTask(this, tgbridge::onServerStarted)
+        Bukkit.getAsyncScheduler().runDelayed(this, { (tgbridge::onServerStarted)() }, 5, TimeUnit.SECONDS)
         tgbridge.init()
     }
 


### PR DESCRIPTION
Фикс под Folia сервера, в ней все sync вызовы запрещены

Прямым аналогом служил бы AsyncScheduler.RunNow(), но получал ошибки (видимо происходит race-condition\гонка состояний)
```
Exception in thread "DefaultDispatcher-worker-3" tgbridge.shaded.kotlin.UninitializedPropertyAccessException: lateinit property loadedIntegrations has not been initialized
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.TelegramBridge.getLoadedIntegrations(TelegramBridge.kt:36)
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.models.TgbridgePlayer.isVanished(TgbridgePlayer.kt:20)
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.TelegramBridge$onPlayerLeave$1.invokeSuspend(TelegramBridge.kt:333)
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.TelegramBridge$onPlayerLeave$1.invoke(TelegramBridge.kt)
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.TelegramBridge$onPlayerLeave$1.invoke(TelegramBridge.kt)
        at tgbridge-0.8.0-paper-1755143961815.jar//dev.vanutp.tgbridge.common.TelegramBridge$wrapMinecraftHandler$1.invokeSuspend(TelegramBridge.kt:390)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
        at tgbridge-0.8.0-paper-1755143961815.jar//tgbridge.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
        Suppressed: tgbridge.shaded.kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3ebcdfa6, Dispatchers.IO]
```
Заменил на отложенное выполнение на 5 секунд (взято рандомно с потолка) и все стало вновь работоспособным 😉