### PR TITLE
Honor Telegram retry_after on HTTP 429 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- honor Telegram's `retry_after` on HTTP 429 (rate limit) responses instead of dropping the message
+
 ### 0.9.10
 
 - fabric, paper: support 26.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-- honor Telegram's `retry_after` on HTTP 429 (rate limit) responses instead of dropping the message
+- honor Telegram's `retry_after` on HTTP 429 (rate limit) responses instead of dropping the message, capped at a few retries so a persistently rate-limited bot fails the request instead of retrying forever
 
 ### 0.9.10
 

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
@@ -438,6 +438,87 @@ private const val HTTP_TOO_MANY_REQUESTS = 429
 // the limit again exactly at the boundary.
 private const val RATE_LIMIT_RETRY_MARGIN_MS = 1000L
 
+// Cap on how many times a single request will wait out Telegram's retry_after
+// before giving up. Honoring retry_after recovers from a transient 429, but a
+// bot that is persistently over the limit (e.g. a busy chat exceeding Telegram's
+// per-group message rate) would otherwise retry forever and wedge the caller, so
+// past this cap we fail the request instead (dropping the message, as before).
+internal const val MAX_RATE_LIMIT_RETRIES = 5
+
+/**
+ * Delay to wait before retrying a rate-limited request, derived from the
+ * `retry_after` Telegram sends on an HTTP 429 response. Returns `null` when
+ * [e] is not a rate-limit error. A small margin is added so we don't hit the
+ * limit again right at the boundary.
+ */
+internal fun rateLimitDelayMs(e: Throwable): Long? =
+    (e as? TelegramException)
+        ?.takeIf { it.errorCode == HTTP_TOO_MANY_REQUESTS }
+        ?.retryAfter
+        ?.let { it.toLong() * 1000 + RATE_LIMIT_RETRY_MARGIN_MS }
+
+internal suspend fun <T> withRetry(
+    logger: ILogger,
+    maxAttempts: Int = 3,
+    initialDelay: Long = 1000L,
+    maxDelay: Long = 300000L,
+    retryExceptions: Set<KClass<out Exception>> = setOf(Exception::class),
+    operation: suspend () -> T,
+): T {
+    var attempt = 0
+    var rateLimitRetries = 0
+    val infiniteRetries = maxAttempts <= 0
+
+    while (true) {
+        try {
+            return operation()
+        } catch (e: Exception) {
+            // Telegram explicitly told us how long to wait (HTTP 429): honor that
+            // instead of using exponential backoff, and don't spend the connection
+            // retry budget on it — rate limiting is not a connection failure.
+            val rateLimitDelay = rateLimitDelayMs(e)
+            if (rateLimitDelay != null) {
+                rateLimitRetries++
+                // Honoring retry_after recovers from a transient 429, but retrying
+                // forever would wedge the caller when the bot is persistently over
+                // the limit, so give up (fail the request) once the cap is reached.
+                if (rateLimitRetries > MAX_RATE_LIMIT_RETRIES) {
+                    logger.error(
+                        "Still rate limited by Telegram after $MAX_RATE_LIMIT_RETRIES retries, giving up",
+                        e,
+                    )
+                    throw e
+                }
+                // Honor retry_after exactly: it must not be clamped to maxDelay
+                // (which only bounds connection backoff). Retrying before the
+                // server-mandated interval would just trigger another 429.
+                logger.warn(
+                    "Rate limited by Telegram, retrying in ${rateLimitDelay / 1000} seconds " +
+                        "(retry $rateLimitRetries/$MAX_RATE_LIMIT_RETRIES)"
+                )
+                delay(rateLimitDelay)
+                continue
+            }
+
+            if (!retryExceptions.contains(e::class)) {
+                logger.error("Not retriable exception", e)
+                throw e
+            }
+            attempt++
+
+            if (!infiniteRetries && attempt >= maxAttempts) {
+                logger.error("Operation failed after $maxAttempts attempts", e)
+                throw e
+            }
+
+            val delay = minOf(initialDelay * (1L shl (attempt - 1)), maxDelay)
+            val attemptText = if (infiniteRetries) "attempt $attempt" else "attempt $attempt/$maxAttempts"
+            logger.warn("Operation failed ($attemptText), retrying in ${delay / 1000} seconds: ${e.javaClass.canonicalName}: ${e.message}")
+            delay(delay)
+        }
+    }
+}
+
 class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogger, private val scope: CoroutineScope) {
     init {
         val proxy = config.advanced.proxy
@@ -609,6 +690,7 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
     private suspend fun <T> retriableCall(f: suspend () -> TgResponse<T>): T {
         val retryConf = config.advanced.connectionRetry
         return withRetry(
+            logger = logger,
             maxAttempts = retryConf.maxAttempts,
             initialDelay = retryConf.initialDelay,
             maxDelay = retryConf.maxDelay,
@@ -623,64 +705,6 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
             call(f)
         }
     }
-
-    private suspend fun <T> withRetry(
-        maxAttempts: Int = 3,
-        initialDelay: Long = 1000L,
-        maxDelay: Long = 300000L,
-        retryExceptions: Set<KClass<out Exception>> = setOf(Exception::class),
-        operation: suspend () -> T
-    ): T {
-        var attempt = 0
-        val infiniteRetries = maxAttempts <= 0
-
-        while (true) {
-            try {
-                return operation()
-            } catch (e: Exception) {
-                // Telegram explicitly told us how long to wait (HTTP 429): honor that
-                // instead of using exponential backoff, and don't spend the connection
-                // retry budget on it — rate limiting is not a connection failure.
-                val rateLimitDelay = rateLimitDelayMs(e)
-                if (rateLimitDelay != null) {
-                    // Honor retry_after exactly: it must not be clamped to maxDelay
-                    // (which only bounds connection backoff). Retrying before the
-                    // server-mandated interval would just trigger another 429.
-                    logger.warn("Rate limited by Telegram, retrying in ${rateLimitDelay / 1000} seconds")
-                    delay(rateLimitDelay)
-                    continue
-                }
-
-                if (!retryExceptions.contains(e::class)) {
-                    logger.error("Not retriable exception", e)
-                    throw e
-                }
-                attempt++
-
-                if (!infiniteRetries && attempt >= maxAttempts) {
-                    logger.error("Operation failed after $maxAttempts attempts", e)
-                    throw e
-                }
-
-                val delay = minOf(initialDelay * (1L shl (attempt - 1)), maxDelay)
-                val attemptText = if (infiniteRetries) "attempt $attempt" else "attempt $attempt/$maxAttempts"
-                logger.warn("Operation failed ($attemptText), retrying in ${delay / 1000} seconds: ${e.javaClass.canonicalName}: ${e.message}")
-                delay(delay)
-            }
-        }
-    }
-
-    /**
-     * Delay to wait before retrying a rate-limited request, derived from the
-     * `retry_after` Telegram sends on an HTTP 429 response. Returns `null` when
-     * [e] is not a rate-limit error. A small margin is added so we don't hit the
-     * limit again right at the boundary.
-     */
-    private fun rateLimitDelayMs(e: Throwable): Long? =
-        (e as? TelegramException)
-            ?.takeIf { it.errorCode == HTTP_TOO_MANY_REQUESTS }
-            ?.retryAfter
-            ?.let { it.toLong() * 1000 + RATE_LIMIT_RETRY_MARGIN_MS }
 
     suspend fun sendMessage(
         chatId: Long,

--- a/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
+++ b/common/src/main/kotlin/dev/vanutp/tgbridge/common/TelegramBot.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.future.future
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -302,10 +303,21 @@ data class TgUpdate(
 )
 
 @Serializable
+data class TgResponseParameters(
+    @SerialName("retry_after")
+    val retryAfter: Int? = null,
+    @SerialName("migrate_to_chat_id")
+    val migrateToChatId: Long? = null,
+)
+
+@Serializable
 data class TgResponse<T>(
     val ok: Boolean,
     val result: T? = null,
     val description: String? = null,
+    @SerialName("error_code")
+    val errorCode: Int? = null,
+    val parameters: TgResponseParameters? = null,
 )
 
 @Serializable
@@ -350,9 +362,20 @@ data class TgDeleteMessageRequest(
     val messageId: Int,
 )
 
-class TelegramException(val responseBody: String?) : Exception(
-    "Telegram exception: ${responseBody ?: "no response body"}"
-)
+class TelegramException(
+    val errorCode: Int? = null,
+    val description: String? = null,
+    val parameters: TgResponseParameters? = null,
+    val responseBody: String? = null,
+) : Exception(
+    "Telegram exception: ${responseBody ?: description ?: "no response body"}"
+) {
+    /**
+     * Number of seconds Telegram asks us to wait before retrying, as sent in the
+     * `parameters.retry_after` field of an HTTP 429 response. `null` if absent.
+     */
+    val retryAfter: Int? get() = parameters?.retryAfter
+}
 
 interface TgApi {
     @GET("getMe")
@@ -408,6 +431,12 @@ interface TgApi {
 }
 
 const val POLL_TIMEOUT_SECONDS = 60
+
+private const val HTTP_TOO_MANY_REQUESTS = 429
+
+// Extra time added on top of Telegram's requested retry_after to avoid hitting
+// the limit again exactly at the boundary.
+private const val RATE_LIMIT_RETRY_MARGIN_MS = 1000L
 
 class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogger, private val scope: CoroutineScope) {
     init {
@@ -529,7 +558,7 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
                         is CancellationException -> break
                         else -> {
                             logger.error(e.message.toString(), e)
-                            delay(1000)
+                            delay(rateLimitDelayMs(e) ?: 1000)
                         }
                     }
                 }
@@ -560,7 +589,20 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
             return f().result!!
         } catch (e: HttpException) {
             val resp = e.response() ?: throw e
-            throw TelegramException(resp.errorBody()?.string())
+            val body = resp.errorBody()?.string()
+            val parsed = body?.let {
+                try {
+                    json.decodeFromString<TgResponse<JsonElement>>(it)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+            throw TelegramException(
+                errorCode = parsed?.errorCode ?: e.code(),
+                description = parsed?.description,
+                parameters = parsed?.parameters,
+                responseBody = body,
+            )
         }
     }
 
@@ -596,6 +638,19 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
             try {
                 return operation()
             } catch (e: Exception) {
+                // Telegram explicitly told us how long to wait (HTTP 429): honor that
+                // instead of using exponential backoff, and don't spend the connection
+                // retry budget on it — rate limiting is not a connection failure.
+                val rateLimitDelay = rateLimitDelayMs(e)
+                if (rateLimitDelay != null) {
+                    // Honor retry_after exactly: it must not be clamped to maxDelay
+                    // (which only bounds connection backoff). Retrying before the
+                    // server-mandated interval would just trigger another 429.
+                    logger.warn("Rate limited by Telegram, retrying in ${rateLimitDelay / 1000} seconds")
+                    delay(rateLimitDelay)
+                    continue
+                }
+
                 if (!retryExceptions.contains(e::class)) {
                     logger.error("Not retriable exception", e)
                     throw e
@@ -614,6 +669,18 @@ class TelegramBot(botApiUrl: String, botToken: String, private val logger: ILogg
             }
         }
     }
+
+    /**
+     * Delay to wait before retrying a rate-limited request, derived from the
+     * `retry_after` Telegram sends on an HTTP 429 response. Returns `null` when
+     * [e] is not a rate-limit error. A small margin is added so we don't hit the
+     * limit again right at the boundary.
+     */
+    private fun rateLimitDelayMs(e: Throwable): Long? =
+        (e as? TelegramException)
+            ?.takeIf { it.errorCode == HTTP_TOO_MANY_REQUESTS }
+            ?.retryAfter
+            ?.let { it.toLong() * 1000 + RATE_LIMIT_RETRY_MARGIN_MS }
 
     suspend fun sendMessage(
         chatId: Long,

--- a/common/src/test/kotlin/dev/vanutp/tgbridge/common/TelegramRateLimitTest.kt
+++ b/common/src/test/kotlin/dev/vanutp/tgbridge/common/TelegramRateLimitTest.kt
@@ -1,10 +1,24 @@
 package dev.vanutp.tgbridge.common
 
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+
+private class NoopLogger : ILogger {
+    override fun info(message: Any) {}
+    override fun warn(message: Any) {}
+    override fun error(message: Any) {}
+    override fun error(message: Any, exc: Exception) {}
+}
+
+private fun rateLimitException(retryAfter: Int) = TelegramException(
+    errorCode = 429,
+    parameters = TgResponseParameters(retryAfter = retryAfter),
+)
 
 class TelegramRateLimitTest {
     private val json = Json { ignoreUnknownKeys = true }
@@ -38,6 +52,35 @@ class TelegramRateLimitTest {
 
         assertEquals(429, exception.errorCode)
         assertEquals(9, exception.retryAfter)
+    }
+
+    @Test
+    fun transient429IsRetriedThenSucceeds() = runBlocking {
+        var calls = 0
+        val result = withRetry(logger = NoopLogger(), retryExceptions = emptySet()) {
+            calls++
+            // retry_after = 0 keeps the test fast (only the ~1s margin is waited)
+            if (calls < 3) throw rateLimitException(retryAfter = 0)
+            "ok"
+        }
+        assertEquals("ok", result)
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun persistent429IsCappedThenGivesUp() = runBlocking {
+        var calls = 0
+        val thrown = assertFailsWith<TelegramException> {
+            // A high connection-retry budget must NOT keep a persistent rate limit
+            // alive: the rate-limit cap is what must stop it.
+            withRetry(logger = NoopLogger(), maxAttempts = 100, retryExceptions = emptySet()) {
+                calls++
+                throw rateLimitException(retryAfter = 0)
+            }
+        }
+        assertEquals(429, thrown.errorCode)
+        // 1 initial attempt + MAX_RATE_LIMIT_RETRIES retries, then it gives up
+        assertEquals(1 + MAX_RATE_LIMIT_RETRIES, calls)
     }
 
     @Test

--- a/common/src/test/kotlin/dev/vanutp/tgbridge/common/TelegramRateLimitTest.kt
+++ b/common/src/test/kotlin/dev/vanutp/tgbridge/common/TelegramRateLimitTest.kt
@@ -1,0 +1,54 @@
+package dev.vanutp.tgbridge.common
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TelegramRateLimitTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun parsesRetryAfterFrom429Body() {
+        // Exact payload returned by the Telegram Bot API on a rate limit.
+        val body =
+            """{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 9","parameters":{"retry_after":9}}"""
+
+        val response = json.decodeFromString<TgResponse<JsonElement>>(body)
+
+        assertEquals(false, response.ok)
+        assertEquals(429, response.errorCode)
+        assertEquals(9, response.parameters?.retryAfter)
+        assertNull(response.result)
+    }
+
+    @Test
+    fun telegramExceptionExposesRetryAfter() {
+        val body =
+            """{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 9","parameters":{"retry_after":9}}"""
+        val response = json.decodeFromString<TgResponse<JsonElement>>(body)
+
+        val exception = TelegramException(
+            errorCode = response.errorCode,
+            description = response.description,
+            parameters = response.parameters,
+            responseBody = body,
+        )
+
+        assertEquals(429, exception.errorCode)
+        assertEquals(9, exception.retryAfter)
+    }
+
+    @Test
+    fun successResponseHasNoError() {
+        val body = """{"ok":true,"result":{"id":1,"first_name":"bot"}}"""
+
+        val response = json.decodeFromString<TgResponse<TgUser>>(body)
+
+        assertEquals(true, response.ok)
+        assertNull(response.errorCode)
+        assertNull(response.parameters)
+        assertEquals(1, response.result?.id)
+    }
+}


### PR DESCRIPTION
Addresses #151.

### Problem
When many messages are sent, Telegram rate-limits the bot with HTTP 429 and a
`parameters.retry_after` field telling the client how many seconds to wait, e.g.:

```json
{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 3","parameters":{"retry_after":3}}
```

tgbridge ignored this. `call()` discarded the structured body, and `withRetry()` only
retried a fixed set of network exceptions — so a 429 surfaced as a non-retriable
`TelegramException` (the `Not retriable exception` log in #151) and the message was
**dropped**. The polling loop also ignored `retry_after` and used a flat 1s backoff,
which can prolong the flood-wait.

### Fix
- Model the response envelope: add `TgResponseParameters` (`retry_after`,
  `migrate_to_chat_id`) and `error_code` / `parameters` to `TgResponse`.
- `TelegramException` now carries `errorCode` / `description` / `parameters` and exposes
  `retryAfter` (`responseBody` kept for backward compatibility).
- `call()` parses the error body into the exception.
- `withRetry()` treats rate limiting as a **distinct retry class**: it waits exactly
  `retry_after` (+ a small margin) and does **not** consume the
  `connectionRetry.maxAttempts` budget, since a rate limit isn't a connection failure.
  The value is honored as-is (not clamped to `maxDelay`, which only bounds connection
  backoff). The polling loop reuses the same helper.
- No new config keys — honoring 429 is correctness, not a preference.

### On the message queue
This PR makes the bot **correct** under rate limiting (stops dropping messages, backs off
exactly as Telegram dictates). A global outgoing **message queue** (proactive
pacing/coalescing to avoid hitting 429 in the first place) is a larger, orthogonal
enhancement that can layer on top — every send already funnels through `retriableCall`.
Happy to follow up separately; leaving #151 open for that.